### PR TITLE
fix-cookie-compatibility-with-4.2

### DIFF
--- a/lib/devise/strategies/rememberable.rb
+++ b/lib/devise/strategies/rememberable.rb
@@ -17,7 +17,12 @@ module Devise
       # the record in the database. If the attempt fails, we pass to another
       # strategy handle the authentication.
       def authenticate!
-        resource = mapping.to.serialize_from_cookie(*remember_cookie)
+        remember_cookie # sets the instance variable
+        if @remember_cookie.length > 2
+          # safe, on this version we only care about the first two values
+          @remember_cookie = @remember_cookie[0..1]
+        end
+        resource = mapping.to.serialize_from_cookie(*@remember_cookie)
 
         unless resource
           cookies.delete(remember_key)


### PR DESCRIPTION
This is a stop gap until we fully deploy rails 5.

This repo will die on the rails 5 cleanup where the reference to this gem/version will be removed keeping the official devise 4.2 implementation.
